### PR TITLE
feat: migrate and concretize rag_pipeline #32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,14 @@ version = "0.1.0"
 description = "AI debate engine for competitive Warhammer predictions"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "ollama>=0.3",
     "pydantic>=2.0",
     "duckdb>=0.10",
+    "chromadb>=0.5.0",
+    "mcp>=1.0.0",
+    "crawl4ai>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/vindicta_oracle.egg-info/PKG-INFO
+++ b/src/vindicta_oracle.egg-info/PKG-INFO
@@ -3,12 +3,15 @@ Name: vindicta-oracle
 Version: 0.1.0
 Summary: AI debate engine for competitive Warhammer predictions
 License-Expression: MIT
-Requires-Python: >=3.10
+Requires-Python: >=3.12
 Description-Content-Type: text/markdown
 License-File: LICENSE
 Requires-Dist: ollama>=0.3
 Requires-Dist: pydantic>=2.0
 Requires-Dist: duckdb>=0.10
+Requires-Dist: chromadb>=0.5.0
+Requires-Dist: mcp>=1.0.0
+Requires-Dist: crawl4ai>=0.4.0
 Provides-Extra: dev
 Requires-Dist: pytest>=8.0; extra == "dev"
 Requires-Dist: ruff>=0.4; extra == "dev"

--- a/src/vindicta_oracle.egg-info/SOURCES.txt
+++ b/src/vindicta_oracle.egg-info/SOURCES.txt
@@ -28,6 +28,9 @@ src/vindicta_oracle/agents/home.py
 src/vindicta_oracle/agents/home_impl.py
 src/vindicta_oracle/agents/rule_sage.py
 src/vindicta_oracle/agents/rule_sage_impl.py
+src/vindicta_oracle/rag_pipeline/__init__.py
+src/vindicta_oracle/rag_pipeline/scraper.py
+src/vindicta_oracle/rag_pipeline/storage.py
 tests/test_agents.py
 tests/test_api.py
 tests/test_grader.py

--- a/src/vindicta_oracle.egg-info/requires.txt
+++ b/src/vindicta_oracle.egg-info/requires.txt
@@ -1,6 +1,9 @@
 ollama>=0.3
 pydantic>=2.0
 duckdb>=0.10
+chromadb>=0.5.0
+mcp>=1.0.0
+crawl4ai>=0.4.0
 
 [api]
 fastapi>=0.109.0

--- a/src/vindicta_oracle/rag_pipeline/__init__.py
+++ b/src/vindicta_oracle/rag_pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""RAG Pipeline package — scraper and storage for rules ingestion."""

--- a/src/vindicta_oracle/rag_pipeline/chunking/semantic.py
+++ b/src/vindicta_oracle/rag_pipeline/chunking/semantic.py
@@ -1,0 +1,23 @@
+"""Semantic markdown chunking."""
+
+import re
+from typing import Iterator
+
+def semantic_markdown_chunker(markdown_text: str, max_chunk_length: int = 2000) -> Iterator[str]:
+    """Split markdown text roughly by headers, preserving context.
+    
+    Args:
+        markdown_text: The markdown content to split.
+        max_chunk_length: Target maximum length of a chunk (soft limit).
+
+    Yields:
+        Chunks of markdown text.
+    """
+    # Split by level 2 headers (##) to keep semantic rule contexts together
+    chunks = re.split(r'(?=\n## )', markdown_text)
+    
+    for chunk in chunks:
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        yield chunk

--- a/src/vindicta_oracle/rag_pipeline/clients/chromadb_client.py
+++ b/src/vindicta_oracle/rag_pipeline/clients/chromadb_client.py
@@ -1,0 +1,48 @@
+"""ChromaDB concrete client for vector storage."""
+
+from typing import Any
+import chromadb
+
+class ChromaDBClient:
+    """Persistent vector store using ChromaDB."""
+
+    def __init__(self, persist_directory: str = "./chroma_db", collection_name: str = "rules") -> None:
+        self.client = chromadb.PersistentClient(path=persist_directory)
+        self.collection = self.client.get_or_create_collection(name=collection_name)
+
+    def upsert(
+        self,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        embeddings: list[list[float]],
+    ) -> None:
+        """Upsert documents with embeddings and metadata."""
+        self.collection.upsert(
+            ids=ids,
+            documents=documents,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+
+    def query(
+        self,
+        query_embeddings: list[list[float]],
+        n_results: int = 5,
+    ) -> dict[str, Any]:
+        """Query the store by embedding similarity."""
+        return self.collection.query(
+            query_embeddings=query_embeddings,
+            n_results=n_results,
+        )
+
+    def get(
+        self,
+        ids: list[str] | None = None,
+        where: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Get documents by ID or filter."""
+        return self.collection.get(
+            ids=ids,
+            where=where,
+        )

--- a/src/vindicta_oracle/rag_pipeline/clients/ollama_client.py
+++ b/src/vindicta_oracle/rag_pipeline/clients/ollama_client.py
@@ -1,0 +1,14 @@
+"""Ollama concrete client for local embeddings."""
+
+import ollama
+
+class OllamaEmbeddingClient:
+    """Provides local embeddings via Ollama."""
+
+    def __init__(self, model: str = "nomic-embed-text") -> None:
+        self.model = model
+
+    def embed(self, text: str) -> list[float]:
+        """Generate an embedding vector for the given text."""
+        response = ollama.embeddings(model=self.model, prompt=text)
+        return response["embedding"]

--- a/src/vindicta_oracle/rag_pipeline/scraper.py
+++ b/src/vindicta_oracle/rag_pipeline/scraper.py
@@ -1,0 +1,213 @@
+"""RAG Pipeline scraper — crawl4ai integration for rules ingestion.
+
+Implements dedicated extraction logic for Wahapedia and 40k.app
+with generic fallback (FR-001), clean markdown conversion (FR-002),
+SHA-256 deduplication (FR-003), and resilient error handling (FR-007).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class CrawlerProtocol(Protocol):
+    """Protocol for web page crawling — enables testing without crawl4ai."""
+
+    async def fetch_markdown(self, url: str) -> str:
+        """Fetch a URL and return cleaned markdown content."""
+        ...
+
+
+@dataclass
+class ScrapedChunk:
+    """A scraped and processed content chunk ready for storage."""
+
+    url: str
+    content_markdown: str
+    content_hash: str
+
+
+@dataclass
+class ScrapeResult:
+    """Result of a scrape operation across multiple URLs."""
+
+    chunks: list[ScrapedChunk] = field(default_factory=list)
+    errors: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def success_count(self) -> int:
+        """Number of successfully scraped chunks."""
+        return len(self.chunks)
+
+    @property
+    def error_count(self) -> int:
+        """Number of failed pages."""
+        return len(self.errors)
+
+
+def compute_content_hash(content: str) -> str:
+    """Compute SHA-256 hash of content for deduplication (FR-003).
+
+    Args:
+        content: Raw UTF-8 text content.
+
+    Returns:
+        Hex-encoded SHA-256 hash string.
+    """
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def extract_markdown_chunks(
+    raw_markdown: str,
+    url: str,
+    chunk_size: int = 2000,
+    chunk_overlap: int = 200,
+) -> list[ScrapedChunk]:
+    """Split raw markdown into overlapping chunks for embedding.
+
+    Args:
+        raw_markdown: The full markdown text from a page.
+        url: Source URL for provenance tracking.
+        chunk_size: Target size per chunk in characters.
+        chunk_overlap: Overlap between consecutive chunks.
+
+    Returns:
+        List of ``ScrapedChunk`` with content and hash.
+    """
+    if not raw_markdown.strip():
+        return []
+
+    chunks: list[ScrapedChunk] = []
+    text = raw_markdown.strip()
+
+    # Split by double newlines (paragraphs) first, then by chunk_size
+    paragraphs = text.split("\n\n")
+    current_chunk = ""
+
+    for paragraph in paragraphs:
+        if len(current_chunk) + len(paragraph) + 2 > chunk_size and current_chunk:
+            chunk_text = current_chunk.strip()
+            if chunk_text:
+                chunks.append(
+                    ScrapedChunk(
+                        url=url,
+                        content_markdown=chunk_text,
+                        content_hash=compute_content_hash(chunk_text),
+                    )
+                )
+            # Start new chunk with overlap from the end of the previous
+            overlap_text = current_chunk[-chunk_overlap:] if chunk_overlap > 0 else ""
+            current_chunk = overlap_text + "\n\n" + paragraph
+        else:
+            current_chunk = (
+                current_chunk + "\n\n" + paragraph if current_chunk else paragraph
+            )
+
+    # Don't forget the last chunk
+    if current_chunk.strip():
+        chunk_text = current_chunk.strip()
+        chunks.append(
+            ScrapedChunk(
+                url=url,
+                content_markdown=chunk_text,
+                content_hash=compute_content_hash(chunk_text),
+            )
+        )
+
+    return chunks
+
+
+async def scrape_url(
+    url: str,
+    crawler: CrawlerProtocol | None = None,
+) -> list[ScrapedChunk]:
+    """Scrape a single URL and return content chunks.
+
+    Args:
+        url: The URL to scrape.
+        crawler: Optional crawler implementation. If None, attempts
+            to use crawl4ai (must be installed).
+
+    Returns:
+        List of content chunks from the page.
+
+    Raises:
+        ImportError: If crawl4ai is not installed and no crawler provided.
+    """
+    if crawler is not None:
+        try:
+            raw_md = await crawler.fetch_markdown(url)
+            return extract_markdown_chunks(raw_md, url)
+        except Exception as exc:
+            logger.error(
+                "Scrape failed for %s: %s",
+                url,
+                str(exc),
+                extra={"url": url, "error_type": type(exc).__name__},
+            )
+            return []
+
+    # Default: use crawl4ai
+    try:
+        from crawl4ai import AsyncWebCrawler  # type: ignore[import-untyped]
+
+        async with AsyncWebCrawler() as web_crawler:
+            result = await web_crawler.arun(url=url)
+            raw_md = result.markdown if hasattr(result, "markdown") else str(result)
+            return extract_markdown_chunks(raw_md, url)
+    except ImportError:
+        raise ImportError(
+            "crawl4ai is required for scraping. "
+            "Install with: pip install 'vindicta-foundation[rag]'"
+        )
+    except Exception as exc:
+        logger.error(
+            "Scrape failed for %s: %s",
+            url,
+            str(exc),
+            extra={"url": url, "error_type": type(exc).__name__},
+        )
+        return []
+
+
+async def scrape_urls(
+    urls: list[str],
+    crawler: CrawlerProtocol | None = None,
+) -> ScrapeResult:
+    """Scrape multiple URLs with resilient error handling (FR-007).
+
+    Failed pages are logged and skipped; remaining pages continue.
+
+    Args:
+        urls: List of URLs to scrape.
+        crawler: Optional crawler implementation.
+
+    Returns:
+        A ``ScrapeResult`` with chunks and errors.
+    """
+    result = ScrapeResult()
+
+    for url in urls:
+        try:
+            chunks = await scrape_url(url, crawler=crawler)
+            result.chunks.extend(chunks)
+            logger.info("Scraped %d chunks from %s", len(chunks), url)
+        except Exception as exc:
+            error_info = {
+                "url": url,
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            }
+            result.errors.append(error_info)
+            logger.error(
+                "Failed to scrape %s: %s (continuing)",
+                url,
+                str(exc),
+            )
+
+    return result

--- a/src/vindicta_oracle/rag_pipeline/storage.py
+++ b/src/vindicta_oracle/rag_pipeline/storage.py
@@ -1,0 +1,213 @@
+"""RAG Pipeline storage — ChromaDB + Ollama embeddings.
+
+Implements embedded ChromaDB with SQLite persistence (FR-004),
+local Ollama embeddings, and versioned upsert logic (FR-006).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from vindicta_foundation.models.rag import RulesSegment
+from vindicta_foundation.rag_pipeline.scraper import ScrapedChunk
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingProvider(Protocol):
+    """Protocol for embedding generation — enables testing without Ollama."""
+
+    def embed(self, text: str) -> list[float]:
+        """Generate an embedding vector for the given text."""
+        ...
+
+
+class VectorStore(Protocol):
+    """Protocol for vector storage — enables testing without ChromaDB."""
+
+    def upsert(
+        self,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        embeddings: list[list[float]],
+    ) -> None:
+        """Upsert documents with embeddings and metadata."""
+        ...
+
+    def query(
+        self,
+        query_embeddings: list[list[float]],
+        n_results: int = 5,
+    ) -> dict[str, Any]:
+        """Query the store by embedding similarity."""
+        ...
+
+    def get(
+        self,
+        ids: list[str] | None = None,
+        where: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Get documents by ID or filter."""
+        ...
+
+
+class RulesStorage:
+    """Storage layer for rules segments with embedding and versioning.
+
+    Uses protocol-based dependency injection so ChromaDB and Ollama
+    can be swapped with mocks for testing.
+    """
+
+    def __init__(
+        self,
+        store: VectorStore,
+        embedder: EmbeddingProvider,
+    ) -> None:
+        self._store = store
+        self._embedder = embedder
+
+    def store_chunk(self, chunk: ScrapedChunk) -> RulesSegment:
+        """Store a scraped chunk with embedding, handling dedup (FR-003).
+
+        If a chunk with the same content_hash already exists, it is
+        skipped. If the URL exists with different content, a new version
+        is created (FR-006).
+
+        Args:
+            chunk: A scraped content chunk.
+
+        Returns:
+            The stored ``RulesSegment``.
+        """
+        # Check for existing content with same hash
+        existing = self._find_by_hash(chunk.content_hash)
+        if existing is not None:
+            logger.info(
+                "Skipping duplicate chunk (hash=%s) for %s",
+                chunk.content_hash[:12],
+                chunk.url,
+            )
+            return existing
+
+        # Check for existing content at same URL (new version)
+        version = self._get_next_version(chunk.url)
+
+        # Generate embedding
+        embedding = self._embedder.embed(chunk.content_markdown)
+
+        # Create segment model
+        segment = RulesSegment(
+            url=chunk.url,  # type: ignore[arg-type]
+            content_markdown=chunk.content_markdown,
+            content_hash=chunk.content_hash,
+            version=version,
+            embedding=embedding,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        # Upsert to vector store
+        segment_id = str(segment.id)
+        self._store.upsert(
+            ids=[segment_id],
+            documents=[chunk.content_markdown],
+            metadatas=[
+                {
+                    "url": chunk.url,
+                    "content_hash": chunk.content_hash,
+                    "version": version,
+                    "timestamp": segment.timestamp.isoformat(),
+                }
+            ],
+            embeddings=[embedding],
+        )
+
+        logger.info(
+            "Stored chunk v%d (hash=%s) from %s",
+            version,
+            chunk.content_hash[:12],
+            chunk.url,
+        )
+        return segment
+
+    def store_chunks(self, chunks: list[ScrapedChunk]) -> list[RulesSegment]:
+        """Store multiple chunks, skipping duplicates (SC-003).
+
+        Args:
+            chunks: List of scraped chunks.
+
+        Returns:
+            List of stored ``RulesSegment`` objects.
+        """
+        segments: list[RulesSegment] = []
+        for chunk in chunks:
+            segment = self.store_chunk(chunk)
+            segments.append(segment)
+        return segments
+
+    def search(
+        self,
+        query: str,
+        n_results: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Search for rules by semantic similarity.
+
+        Args:
+            query: Natural language search query.
+            n_results: Maximum results to return.
+
+        Returns:
+            List of result dicts with document, metadata, and distance.
+        """
+        query_embedding = self._embedder.embed(query)
+        raw_results = self._store.query(
+            query_embeddings=[query_embedding],
+            n_results=n_results,
+        )
+
+        results: list[dict[str, Any]] = []
+        documents = raw_results.get("documents", [[]])[0]
+        metadatas = raw_results.get("metadatas", [[]])[0]
+        distances = raw_results.get("distances", [[]])[0]
+
+        for doc, meta, dist in zip(documents, metadatas, distances):
+            results.append(
+                {
+                    "content": doc,
+                    "metadata": meta,
+                    "distance": dist,
+                }
+            )
+        return results
+
+    def _find_by_hash(self, content_hash: str) -> RulesSegment | None:
+        """Look up an existing segment by content hash."""
+        try:
+            result = self._store.get(where={"content_hash": content_hash})
+            docs: list[str] = result.get("documents", [])
+            if docs:
+                metas: list[dict[str, Any]] = result.get("metadatas", [])
+                meta = metas[0] if metas else {}
+                return RulesSegment(
+                    url=meta.get("url", "https://unknown"),
+                    content_markdown=docs[0],
+                    content_hash=content_hash,
+                    version=int(meta.get("version", 1)),
+                )
+        except Exception:
+            pass
+        return None
+
+    def _get_next_version(self, url: str) -> int:
+        """Get the next version number for a URL."""
+        try:
+            result = self._store.get(where={"url": url})
+            metas: list[dict[str, Any]] = result.get("metadatas", [])
+            if metas:
+                versions = [int(m.get("version", 1)) for m in metas]
+                return max(versions) + 1
+        except Exception:
+            pass
+        return 1


### PR DESCRIPTION
## Description
Migrates the `rag_pipeline` out of `vindicta-foundation` to the `vindicta-oracle` package. Also adds concrete implementations for Ollama and ChromaDB, and introduces semantic markdown chunking for rules ingestion.

## Resolves
- fixes #32
- fixes #33
- fixes #34
