### PR TITLE
fix: resolve SonarCloud bugs and vulnerabilities

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=docs-sphinx/_build/**

--- a/src/vindicta_oracle/api.py
+++ b/src/vindicta_oracle/api.py
@@ -1,5 +1,7 @@
 """Meta-Oracle API - REST interface for list grading and council debates."""
 
+import os
+
 from fastapi import FastAPI, APIRouter, HTTPException, Depends
 
 from vindicta_oracle.grader import ListGrader
@@ -57,4 +59,5 @@ app.include_router(router)
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    host = os.environ.get("ORACLE_HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=8000)

--- a/src/vindicta_oracle/engine.py
+++ b/src/vindicta_oracle/engine.py
@@ -39,15 +39,50 @@ class DebateEngine:
         ]
         self.num_rounds = num_rounds
 
-    def run_debate(self, context: DebateContext) -> DebateTranscript:
+    def run_debate(
+        self,
+        context: DebateContext | None = None,
+        *,
+        topic: str | None = None,
+        player1_faction: str | None = None,
+        player2_faction: str | None = None,
+        player1_list: str = "",
+        player2_list: str = "",
+        mission: str | None = None,
+        terrain: str | None = None,
+        additional_context: str | None = None,
+    ) -> DebateTranscript:
         """Execute the full debate protocol.
+
+        Accepts either a pre-built DebateContext or individual keyword
+        arguments for convenience. If ``context`` is provided the keyword
+        arguments are ignored.
 
         Args:
             context: The matchup context (factions, lists, mission, etc.)
+            topic: Convenience alias – mapped to additional_context.
+            player1_faction: Faction name for player 1.
+            player2_faction: Faction name for player 2.
+            player1_list: Army list for player 1.
+            player2_list: Army list for player 2.
+            mission: Mission name.
+            terrain: Terrain description.
+            additional_context: Extra context for the debate.
 
         Returns:
             Complete debate transcript with all rounds, votes, and consensus
         """
+        if context is None:
+            context = DebateContext(
+                player1_faction=player1_faction or "Unknown",
+                player1_list=player1_list,
+                player2_faction=player2_faction or "Unknown",
+                player2_list=player2_list,
+                mission=mission,
+                terrain=terrain,
+                additional_context=additional_context or topic,
+            )
+
         transcript = DebateTranscript(context=context)
 
         self._print_header(context)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -254,7 +254,7 @@ REASONING: Space Marines have the advantage.
         result = agent.vote(sample_transcript)
 
         assert "Player 1" in result.prediction
-        assert result.win_probability == 0.65
+        assert result.win_probability == pytest.approx(0.65)
 
     def test_vote_parses_player2_winner(self, mock_client, sample_transcript):
         """vote() should correctly parse Player 2 as winner."""
@@ -267,7 +267,7 @@ REASONING: Orks will overwhelm.
         result = agent.vote(sample_transcript)
 
         assert "Player 2" in result.prediction
-        assert result.win_probability == 0.70
+        assert result.win_probability == pytest.approx(0.70)
 
     def test_vote_parses_draw(self, mock_client, sample_transcript):
         """vote() should correctly parse Draw prediction."""
@@ -280,7 +280,7 @@ REASONING: Evenly matched.
         result = agent.vote(sample_transcript)
 
         assert "Draw" in result.prediction
-        assert result.win_probability == 0.50
+        assert result.win_probability == pytest.approx(0.50)
 
     def test_vote_handles_malformed_response(self, mock_client, sample_transcript):
         """vote() should gracefully handle malformed LLM responses."""
@@ -290,7 +290,7 @@ REASONING: Evenly matched.
 
         # Should still return a Vote, defaulting where needed
         assert isinstance(result, Vote)
-        assert result.win_probability == 0.60
+        assert result.win_probability == pytest.approx(0.60)
 
     def test_vote_clamps_probability(self, mock_client, sample_transcript):
         """vote() should clamp probability to 0.0-1.0 range."""

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -61,7 +61,7 @@ async def test_grade_valid_list():
     assert response.score > 0
     assert response.grade in ["A", "B", "C", "D", "F"]
     assert "home" in response.analysis
-    assert response.council_verdict["confidence"] == 0.8
+    assert response.council_verdict["confidence"] == pytest.approx(0.8)
 
 
 def test_scoring_formula():


### PR DESCRIPTION
## Summary

Fix 14 bugs and 1 vulnerability flagged by SonarCloud across the vindicta-oracle codebase.

## Changes

### Security Fix (S8392) — BLOCKER
- **`src/vindicta_oracle/api.py`**: Changed `host=\"0.0.0.0\"` to `host=\"127.0.0.1\"` (configurable via `ORACLE_HOST` env var) to prevent binding to all network interfaces.

### Bug Fix (S930) — BLOCKER × 8
- **`src/vindicta_oracle/engine.py`**: Updated `run_debate()` to accept optional keyword arguments (`topic`, `player1_faction`, `player2_faction`, etc.) alongside the existing `DebateContext` parameter. This restores backwards compatibility with the old call signature while keeping the new API as the primary interface.

### Bug Fix (S1244) — MAJOR × 5
- **`tests/test_agents.py`** (L257, 270, 283, 293): Replaced `== float_literal` with `== pytest.approx(float_literal)` for floating-point comparisons.
- **`tests/test_grader.py`** (L64): Same fix.

### Generated Code Exclusion (S2189) — BLOCKER
- **`sonar-project.properties`** (new): Added `sonar.exclusions=docs-sphinx/_build/**` to exclude Sphinx-generated JavaScript from analysis. The infinite loop bug is in upstream `searchtools.js` shipped by Sphinx.

## SonarCloud Issues Resolved

| Rule | Severity | Count | Description |
|------|----------|-------|-------------|
| S8392 | BLOCKER | 1 | Bind to all network interfaces |
| S930 | BLOCKER | 8 | Function signature mismatch |
| S1244 | MAJOR | 5 | Float equality comparisons |
| S2189 | BLOCKER | 1 | Infinite loop in generated JS |
| **Total** | | **15** | |